### PR TITLE
node_run Win & Linux shortcuts conflicted with search pane regexp switch binding.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,9 @@
 [
-  {"keys": ["alt+r"], "command": "node_run"},
+  {"keys": ["alt+r"], "command": "node_run", "context":
+    [
+      { "key": "setting.is_widget", "operator": "equal", "operand": false }
+    ]
+  },
   {"keys": ["alt+d"], "command": "node_drun"},
   {"keys": ["ctrl+alt+r"], "command": "node_run_arguments"},
   {"keys": ["ctrl+alt+d"], "command": "node_drun_arguments"}

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,9 @@
 [
-  {"keys": ["alt+r"], "command": "node_run"},
+  {"keys": ["alt+r"], "command": "node_run", "context":
+    [
+      { "key": "setting.is_widget", "operator": "equal", "operand": false }
+    ]
+  },
   {"keys": ["alt+d"], "command": "node_drun"},
   {"keys": ["ctrl+alt+r"], "command": "node_run_arguments"},
   {"keys": ["ctrl+alt+d"], "command": "node_drun_arguments"}


### PR DESCRIPTION
And here's the fix. It disables the `alt+r` binding if a widget is focused. I hope it doesn't affect usability of the shortcut  much (I keep the package just in case).
