### PR TITLE
Fix Issue #3 (Stop running script)

### DIFF
--- a/Nodejs.sublime-build
+++ b/Nodejs.sublime-build
@@ -1,5 +1,15 @@
 {
   "cmd": ["node", "$file"],
   "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
-  "selector": "source.js"
+  "selector": "source.js",
+  "shell":true,
+  "encoding": "cp1252",
+  "windows":
+    {
+    	"cmd": ["taskkill /F /IM node.exe & node", "$file"]
+    },
+  "linux":
+    {
+        "cmd": ["killall node; node", "$file"]
+    }
 }


### PR DESCRIPTION
Hi! 
I fixed this issue, now is working for Windows and Linux.
The new builder kills all running node process before the new execute.
