### PR TITLE
updated url for windows installation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ or using git with the below commands:
 
 *Windows*
 
-    `git clone git://github.com/tanepiper/SublimeText-Nodejs.git "%APPDATA%\Sublime Text 2\Packages\Nodejs"`
+    `git clone https://github.com/tanepiper/SublimeText-Nodejs "%APPDATA%\Sublime Text 2\Packages\Nodejs"`
 
 Build Systems
 -------------


### PR DESCRIPTION
Hi, I've changed url for windows installer because I was getting an error when trying to clone via git: protocol:

E:\Documents and Settings\Tobii>git clone git://github.com/tanepiper/SublimeText
-Nodejs.git "%APPDATA%\Sublime Text 2\Packages\Nodejs"
Cloning into 'E:\Documents and Settings\XXX\Application Data\Sublime Text 2\Pa
ckages\Nodejs'...
fatal: unable to connect to github.com:
github.com[0: 204.232.175.90]: errno=No such file or directory
