### PR TITLE
add env variable 'NODE_PATH' to command runtime

### DIFF
--- a/Nodejs.py
+++ b/Nodejs.py
@@ -33,6 +33,8 @@ class NodeCommand(sublime_plugin.TextCommand):
       self.active_view().run_command('save')
     if command[0] == 'node' and s.get('node_command'):
       command[0] = s.get('node_command')
+      if 'env' not in kwargs:
+        kwargs['env'] = {"NODE_PATH": s.get('node_path')}
     if command[0] == 'npm' and s.get('npm_command'):
       command[0] = s.get('npm_command')
     if not callback:

--- a/Nodejs.sublime-settings
+++ b/Nodejs.sublime-settings
@@ -6,6 +6,8 @@
   "node_command": false,
   // Same for NPM command
   "npm_command": false,
+  // as 'NODE_PATH' environment variable for node runtime
+  "node_path": false,
 
   "expert_mode": false,
 

--- a/lib/command_thread.py
+++ b/lib/command_thread.py
@@ -21,12 +21,13 @@ def _make_text_safeish(text, fallback_encoding):
   return unitext
 
 class CommandThread(threading.Thread):
-  def __init__(self, command, on_done, working_dir="", fallback_encoding=""):
+  def __init__(self, command, on_done, working_dir="", fallback_encoding="", env={}):
     threading.Thread.__init__(self)
     self.command = command
     self.on_done = on_done
     self.working_dir = working_dir
     self.fallback_encoding = fallback_encoding
+    self.env = env
 
   def run(self):
     try:
@@ -37,7 +38,7 @@ class CommandThread(threading.Thread):
         os.chdir(self.working_dir)
       proc = subprocess.Popen(self.command,
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        shell=shell, universal_newlines=True)
+        shell=shell, universal_newlines=True, env=self.env)
       output = proc.communicate()[0]
       # if sublime's python gets bumped to 2.7 we can just do:
       # output = subprocess.check_output(self.command)


### PR DESCRIPTION
without 'NODE_PATH' env variable, node wouldn't be able to require modules installed by 'npm -g'
