### PR TITLE
Changed path.exists / existsSync to fs.exists / existsSync

### DIFF
--- a/Nodejs.sublime-completions
+++ b/Nodejs.sublime-completions
@@ -544,6 +544,14 @@
             "contents": "fs.closeSync(${1:fd});$0"
         },
         {
+            "trigger": "fs.exists(path, callback);",
+            "contents": "fs.exists(${1:path}, ${2:callback});$0"
+        },
+        {
+            "trigger": "fs.existsSync(path);",
+            "contents": "fs.existsSync(${1:path});$0"
+        },
+        {
             "trigger": "fs.open(path, flags, mode, callback);",
             "contents": "fs.open(${1:path}, ${2:flags}, ${3:mode}, ${4:callback});$0"
         },
@@ -1022,14 +1030,6 @@
         {
             "trigger": "path.extname(path);",
             "contents": "path.extname(${1:path});$0"
-        },
-        {
-            "trigger": "path.exists(path, callback);",
-            "contents": "path.exists(${1:path}, ${2:callback});$0"
-        },
-        {
-            "trigger": "path.existsSync(path);",
-            "contents": "path.existsSync(${1:path});$0"
         },
         {
             "trigger": "path._makeLong(path);",


### PR DESCRIPTION
The `exists` / `existsSync` function got moved from path to fs in Node-version [0.7.1](http://blog.nodejs.org/2012/01/23/node-v0-7-1/).
