### PR TITLE
Fix the Node.js run broken in Windows.

### DIFF
--- a/Nodejs.py
+++ b/Nodejs.py
@@ -33,8 +33,8 @@ class NodeCommand(sublime_plugin.TextCommand):
       self.active_view().run_command('save')
     if command[0] == 'node' and s.get('node_command'):
       command[0] = s.get('node_command')
-      if 'env' not in kwargs:
-        kwargs['env'] = {"NODE_PATH": s.get('node_path')}
+    if command[0] == 'node' and s.get('node_path'):
+      kwargs['env'] = { "NODE_PATH" : str(s.get('node_path')) }
     if command[0] == 'npm' and s.get('npm_command'):
       command[0] = s.get('npm_command')
     if not callback:

--- a/lib/command_thread.py
+++ b/lib/command_thread.py
@@ -27,7 +27,8 @@ class CommandThread(threading.Thread):
     self.on_done = on_done
     self.working_dir = working_dir
     self.fallback_encoding = fallback_encoding
-    self.env = env
+    self.env = os.environ.copy()
+    self.env.update(env)
 
   def run(self):
     try:


### PR DESCRIPTION
Hi, my previous pull req #39 seems has broken Node.js run in Windows,
because some necessary variables were absent in the added env parameter. ( as mentioned [here](http://docs.python.org/2/library/subprocess.html) )

``` python
 proc = subprocess.Popen(self.command,
        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
        shell=shell, universal_newlines=True, env=self.env)
```

So I fixed it by making a copy of current sys env first, as:

``` python
self.env = os.environ.copy()
self.env.update(env)
```
