### PR TITLE
updated `is_enabled` functions to return booleans

### DIFF
--- a/Nodejs.py
+++ b/Nodejs.py
@@ -97,7 +97,8 @@ class NodeWindowCommand(NodeCommand, sublime_plugin.WindowCommand):
   # only one.
   def is_enabled(self):
     if self._active_file_name() or len(self.window.folders()) == 1:
-      return os.path.realpath(self.get_working_dir())
+        return True if os.path.realpath(self.get_working_dir()) else False
+    return False
 
   def get_file_name(self):
     return ''
@@ -122,8 +123,9 @@ class NodeTextCommand(NodeCommand, sublime_plugin.TextCommand):
 
   def is_enabled(self):
     # First, is this actually a file on the file system?
-    if self.view.file_name() and len(self.view.file_name()) > 0:
-      return os.path.realpath(self.get_working_dir())
+    if self._active_file_name() or len(self.window.folders()) == 1:
+        return True if os.path.realpath(self.get_working_dir()) else False
+    return False
 
   def get_file_name(self):
     return os.path.basename(self.view.file_name())


### PR DESCRIPTION
Per the [API](http://www.sublimetext.com/docs/3/api_reference.html#sublime_plugin.TextCommand), `sublime_plugin` `ApplicationCommand`s, `WindowCommand`s, and `TextCommand`s `is_enabled` function, if defined, needs to return a boolean value. With the current code, the console is filled with error messages like

```
Traceback (most recent call last):
  File "/opt/sublime_text/sublime_plugin.py", line 445, in is_enabled_
    raise ValueError("is_enabled must return a bool", self)
ValueError: ('is_enabled must return a bool', <Nodejs.Nodejs.NodeUglifyCommand object at 0x7f76c2796710>)
```
So, I changed the `is_enabled()` code from
```python
if self._active_file_name() or len(self.window.folders()) == 1:
    return os.path.realpath(self.get_working_dir())
```
to
```python
if self._active_file_name() or len(self.window.folders()) == 1:
    return True if os.path.realpath(self.get_working_dir()) else False
return False
```

Hopefully this is what you were intending with these functions. I noticed in the [ST2 code](https://github.com/tanepiper/SublimeText-Nodejs/blob/master/Nodejs.py#L132-133) that the full text of `is_enabled()` is just
```python
return True
```
so I'm not *exactly* sure what you want, but obviously feel free to make corrections if you want.

Matt