### PR TITLE
disable default keybinds to avoid conflicts with existing user preferences

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,10 +1,10 @@
 [
-  {"keys": ["alt+r"], "command": "node_run", "context":
-    [
-      { "key": "setting.is_widget", "operator": "equal", "operand": false }
-    ]
-  },
-  {"keys": ["alt+d"], "command": "node_drun"},
-  {"keys": ["ctrl+alt+r"], "command": "node_run_arguments"},
-  {"keys": ["ctrl+alt+d"], "command": "node_drun_arguments"}
+  // {"keys": ["alt+r"], "command": "node_run", "context":
+  //   [
+  //     { "key": "setting.is_widget", "operator": "equal", "operand": false }
+  //   ]
+  // },
+  // {"keys": ["alt+d"], "command": "node_drun"},
+  // {"keys": ["ctrl+alt+r"], "command": "node_run_arguments"},
+  // {"keys": ["ctrl+alt+d"], "command": "node_drun_arguments"}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,6 @@
 [
-  {"keys": ["ctrl+r"], "command": "node_run"},
-  {"keys": ["ctrl+d"], "command": "node_drun"},
-  {"keys": ["ctrl+alt+r"], "command": "node_run_arguments"},
-  {"keys": ["ctrl+alt+d"], "command": "node_drun_arguments"}
+  // {"keys": ["ctrl+r"], "command": "node_run"},
+  // {"keys": ["ctrl+d"], "command": "node_drun"},
+  // {"keys": ["ctrl+alt+r"], "command": "node_run_arguments"},
+  // {"keys": ["ctrl+alt+d"], "command": "node_drun_arguments"}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,10 +1,10 @@
 [
-  {"keys": ["alt+r"], "command": "node_run", "context":
-    [
-      { "key": "setting.is_widget", "operator": "equal", "operand": false }
-    ]
-  },
-  {"keys": ["alt+d"], "command": "node_drun"},
-  {"keys": ["ctrl+alt+r"], "command": "node_run_arguments"},
-  {"keys": ["ctrl+alt+d"], "command": "node_drun_arguments"}
+  // {"keys": ["alt+r"], "command": "node_run", "context":
+  //   [
+  //     { "key": "setting.is_widget", "operator": "equal", "operand": false }
+  //   ]
+  // },
+  // {"keys": ["alt+d"], "command": "node_drun"},
+  // {"keys": ["ctrl+alt+r"], "command": "node_run_arguments"},
+  // {"keys": ["ctrl+alt+d"], "command": "node_drun_arguments"}
 ]


### PR DESCRIPTION
Just wasted some time debugging why my Alt+D keybind wasn't working and finally found out it was due to this package.

So I'd suggest to stick to ST's package recommendations and not add any defaults, but instead let the users copy them if needed to avoid any conflicts