### PR TITLE
disable autostartup of builddocs

### DIFF
--- a/Nodejs.py
+++ b/Nodejs.py
@@ -72,7 +72,9 @@ def create_output_panel():
 
 def plugin_loaded():
     check_and_install_dependencies()
-    generate_completions()      
+    st_pref = sublime.load_settings('NodeJS.sublime-settings')
+    if st_pref.get('run_builddocs_at_startup'):
+        generate_completions()
     if Nvm.is_installed():
         info('Node.js version from NVM is ' + Nvm.node_version())
 

--- a/Nodejs.sublime-settings
+++ b/Nodejs.sublime-settings
@@ -8,6 +8,8 @@
   "npm_command": false,
   // as 'NODE_PATH' environment variable for node runtime
   "node_path": false,
+  // build completions on each startup
+  "run_builddocs_at_startup": false,
 
   "expert_mode": false,
 


### PR DESCRIPTION
user config `run_builddocs_at_startup` in `NodeJS.sublime-settings` to reenable

closes https://github.com/tanepiper/SublimeText-Nodejs/issues/92